### PR TITLE
Wrong cadHelpers.printWarning() change to right self.cadHelpers.print…

### DIFF
--- a/ExportOpenEMSDialog.py
+++ b/ExportOpenEMSDialog.py
@@ -728,7 +728,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 		for item in updatedItems:
 			newName = groupName + ", " + itemNewName + ", " + item.text(0)[len(searchStr)+2:]	#must take end of mesh priority item name, means length of searchStr + len(", ")
-			cadHelper.printWarning(f"Updating {item.text(0)} -> {newName}")
+			self.cadHelpers.printWarning(f"Updating {item.text(0)} -> {newName}")
 			item.setText(0, newName)
 
 	def renameMeshPriorityTreeViewItem(self, itemOldName, itemNewName):
@@ -740,7 +740,7 @@ class ExportOpenEMSDialog(QtCore.QObject):
 
 		for item in updatedItems:
 			newName = "Grid, " + itemNewName + ", " + item.text(0)[len(searchStr)+2:]	#must take end of mesh priority item name, means length of searchStr + len(", ")
-			cadHelper.printWarning(f"Updating {item.text(0)} -> {newName}")
+			self.cadHelpers.printWarning(f"Updating {item.text(0)} -> {newName}")
 			item.setText(0, newName)
 
 	def renameTreeViewItem(self, treeViewRef, itemOldName, itemNewName):

--- a/utilsOpenEMS/GuiHelpers/BlenderHelpers.py
+++ b/utilsOpenEMS/GuiHelpers/BlenderHelpers.py
@@ -9,6 +9,8 @@ from mathutils import Vector
 
 class BlenderToCadObject:
     def __init__(self, blenderObj):
+        super(BlenderHelpers, self).__init__(APP_DIR)
+
         self.Label = blenderObj.name
         try:
             self.Name = blenderObj['freeCadId']
@@ -141,10 +143,18 @@ class BlenderHelpers(CadInterface):
             #       context override is needed
             #       https://docs.blender.org/api/current/bpy.ops.html
             #
+            #       export STL function: https://docs.blender.org/api/current/bpy.ops.export_mesh.html
+            #           there is probably problem with units, Blender by default wants to set cm and we want mm
+            #
             override = bpy.context.copy()
             override["selected_objects"] = [ob]
             with bpy.context.temp_override(**override):
-                bpy.ops.export_mesh.stl(filepath=str(exportFileName), use_selection=True)
+                bpy.ops.export_mesh.stl(
+                    filepath=str(exportFileName),
+                    use_selection=True,
+                    ascii=True,
+                    use_mesh_modifiers=True
+                )
 
             ob.select_set(False)
 


### PR DESCRIPTION
…Warning(), causing error and due there is no try/except used in stopped app to rename grid settings item. Now running ok.