### PR TITLE
Repaired conductive sheet octave code generate, OBJECTS IN MATERIAL are gneerated as polygons

### DIFF
--- a/documentation/help/index.html
+++ b/documentation/help/index.html
@@ -3,9 +3,8 @@
       </head>
       <body>
             <h1>OpenEMS Simulation Creator help 0v1</h1>
-            <p>
-               ...TBD...
-            </p>
-            <a href="../programmerGuide/index.html">Programmer's Guide for OpenEMS Simulation Creator addon</a>
+            <ul>
+                <li><a href="../programmerGuide/index.html">Programmer's Guide for OpenEMS Simulation Creator addon</a></li>
+            </ul>
       </body>
 </html>

--- a/documentation/programmerGuide/h5_file_read_time_domain.html
+++ b/documentation/programmerGuide/h5_file_read_time_domain.html
@@ -1,0 +1,57 @@
+<html>
+      <head>
+      </head>
+      <body>
+            <h1>Read .h5 file example</h1>
+            <pre>
+#dump read
+[portEtField portEtMesh] = ReadHDF5Dump([output_dir '/port_ET.h5']);
+
+#
+# Choose node using indexing inside E field box, there is mesh variable which hold distancies between nodes
+#
+for zCoord = 1:3
+  figure;
+  title(["E-field at Z layer " num2str(zCoord)]);
+
+  for row = 1:7
+    for col = 1:3
+      portEx = [];
+      portEy = [];
+      portEz = [];
+
+      nodeIndexX = row;
+      nodeIndexY = col;
+      nodeIndexZ = zCoord;
+
+      for k = 1:length(portEtField.TD.values)
+        portEx = [portEx portEtField.TD.values{k}(nodeIndexX, nodeIndexY, nodeIndexZ,1)];
+        portEy = [portEy portEtField.TD.values{k}(nodeIndexX, nodeIndexY, nodeIndexZ,2)];
+        portEz = [portEz portEtField.TD.values{k}(nodeIndexX, nodeIndexY, nodeIndexZ,3)];
+      end
+
+      portEx = portEx .* 1e-3;
+      portEy = portEy .* 1e-3;
+      portEz = portEz .* 1e-3;
+
+      subplot(7,3,3*(row-1)+col);
+      hold on;
+      ylim([-1, 1]);
+      plot(portEx);
+      plot(portEy);
+      plot(portEz);
+
+      legend("X","Y","Z")
+
+  ##    figure;
+  ##
+  ##    portETotal = abs(sqrt(portEx.^2 + portEy.^2 + portEz.^2))
+  ##    title("E field total value");
+  ##    plot(portETotal)
+
+    end
+  end
+end
+            </pre>
+      </body>
+</html>

--- a/documentation/programmerGuide/index.html
+++ b/documentation/programmerGuide/index.html
@@ -4,7 +4,9 @@
       <body>
             <h1>Programmer Guide for 0v1</h1>
             <p>
-               ...TBD...
+               <ul>
+                   <li><a href="h5_file_read_time_domain.html">Read .h5 file</a></li>
+               </ul>
             </p>
       </body>
 </html>

--- a/experiments/AddCircWaveGuidePort3.m
+++ b/experiments/AddCircWaveGuidePort3.m
@@ -1,0 +1,123 @@
+function [CSX,port] = AddCircWaveGuidePort2( CSX, prio, portnr, start, stop, dir, radius, mode_name, pol_ang, exc_amp, varargin )
+% function [CSX,port] = AddCircWaveGuidePort( CSX, prio, portnr, start, stop, radius, mode_name, pol_ang, exc_amp, varargin )
+% 
+% Create a circular waveguide port, including an optional excitation and probes
+% 
+% Note: - The excitation will be located at the start position in the given direction
+%       - The voltage and current probes at the stop position in the given direction
+%
+% input:
+%   CSX:        complete CSX structure (must contain a mesh)
+%   prio:       priority of primitives
+%   start:      start coordinates of waveguide port box
+%   stop:       stop  coordinates of waveguide port box
+%   radius:     circular waveguide radius (in meter)
+%   mode_name:  mode name, e.g. 'TE11' or 'TM21'
+%   pol_ang:    polarization angle (e.g. 0 = horizontal, pi/2 = vertical)
+%   exc_amp:    excitation amplitude (set 0 to be passive)
+%
+% optional (key/values):
+%   varargin:   optional additional excitations options, see also AddExcitation
+%   'PortNamePrefix': a prefix to the port name
+%
+% output:
+%   CSX:        modified CSX structure
+%   port:       port structure to use with calcPort
+%
+% example:
+%   % create a TE11 circular waveguide mode, using cylindircal coordinates
+%   start=[mesh.r(1)   mesh.a(1)   0  ];
+%   stop =[mesh.r(end) mesh.a(end) 100];
+%   [CSX,port] = AddCircWaveGuidePort( CSX, 99, 1, start, stop, 320e-3, 'TE11', 0, 1);
+%
+% openEMS matlab interface
+% -----------------------
+% (c) 2013 Thorsten Liebig (thorsten.liebig@gmx.de)
+%
+% See also InitCSX, AddExcitation, calcWGPort, calcPort
+
+if (~strcmpi(mode_name(1:2),'TE'))
+    error 'currently only TE type modes are supported'
+end
+
+if (nargin<10)
+    exc_amp = 0;
+end
+if (nargin<9)
+    pol_ang = 0;
+end
+
+pnm = 0;
+n = str2double(mode_name(3));
+m = str2double(mode_name(4));
+
+% values by David M. Pozar, Microwave Engineering, third edition
+if ((n==0) && (m==1))
+    pnm = 3.832;
+elseif ((n==1) && (m==1))
+    pnm = 1.841;
+elseif ((n==2) && (m==1))
+    pnm = 3.054;
+elseif ((n==0) && (m==2))
+    pnm = 7.016;
+elseif ((n==1) && (m==2))
+    pnm = 5.331;
+elseif ((n==2) && (m==2))
+    pnm = 6.706;
+elseif ((n==0) && (m==3))
+    pnm = 10.174;
+elseif ((n==1) && (m==3))
+    pnm = 8.536;
+elseif ((n==2) && (m==3))
+    pnm = 9.970;
+else
+    error 'invalid TE_nm mode'
+end
+
+if ~isfield(CSX,'RectilinearGrid')
+    error 'mesh needs to be defined! Use DefineRectGrid() first!';
+end
+
+unit = CSX.RectilinearGrid.ATTRIBUTE.DeltaUnit;
+kc = pnm/radius;
+kc_draw = kc*unit;
+
+angle = ['a-' num2str(pol_ang)];
+% functions by David M. Pozar, Microwave Engineering, third edition
+% electric field mode profile
+func_Er = [ num2str(-1/kc_draw^2,15) '/rho*cos(' angle ')*j1('  num2str(kc_draw,15) '*rho)'];
+func_Ea = [ num2str(1/kc_draw,15) '*sin(' angle ')*0.5*(j0('  num2str(kc_draw,15) '*rho)-jn(2,'  num2str(kc_draw,15) '*rho))'];
+
+% magnetic field mode profile
+func_Hr = [ num2str(-1/kc_draw,15) '*sin(' angle ')*0.5*(j0('  num2str(kc_draw,15) '*rho)-jn(2,'  num2str(kc_draw,15) '*rho))'];
+func_Ha = [ num2str(-1/kc_draw^2,15) '/rho*cos(' angle ')*j1('  num2str(kc_draw,15) '*rho)'];
+
+if (CSX.ATTRIBUTE.CoordSystem==1)
+    func_E = {func_Er, func_Ea, 0};
+    func_H = {func_Hr, func_Ha, 0};
+else
+    func_Ex = ['(' func_Er '*cos(a) - ' func_Ea '*sin(a) ) * (rho<' num2str(radius/unit) ')'];
+    func_Ey = ['(' func_Er '*sin(a) + ' func_Ea '*cos(a) ) * (rho<' num2str(radius/unit) ')'];
+    %func_E = {func_Ex, func_Ey, 0};
+    
+    func_Hx = ['(' func_Hr '*cos(a) - ' func_Ha '*sin(a) ) * (rho<' num2str(radius/unit) ')'];
+    func_Hy = ['(' func_Hr '*sin(a) + ' func_Ha '*cos(a) ) * (rho<' num2str(radius/unit) ')'];
+    %func_H = {func_Hx, func_Hy, 0};
+
+    %calculate indexes for Ex,Ey,Hx,Hy function based on orientation of waveguide
+    %this is here to assign wave functions to right axis when wave propagation is in X,Y or Z direction
+    dir = DirChar2Int(dir);
+    dirP = mod((dir+1),3)+1;
+    dirPP = mod((dir+2),3)+1;
+
+    func_E{dir+1} = 0;
+    func_E{dirP} = func_Ex;
+    func_E{dirPP} = func_Ey;
+
+    func_H{dir+1} = 0;
+    func_H{dirP} = func_Hx;
+    func_H{dirPP} = func_Hy;
+end
+
+[CSX,port] = AddWaveGuidePort( CSX, prio, portnr, start, stop, dir, func_E, func_H, kc, exc_amp, varargin{:} );
+


### PR DESCRIPTION
When there was conductive sheet material it was importing .stl objects but openEMS for conductive sheet material can use just internal geometries to be considered in simulation, hterefor now it generate polygons based on object boundary box or if sketch is used then added as polygon.